### PR TITLE
Fix callback for PopScope

### DIFF
--- a/lib/screens/note_editor_screen.dart
+++ b/lib/screens/note_editor_screen.dart
@@ -61,7 +61,7 @@ class _NoteEditorScreenState extends State<NoteEditorScreen> {
   Widget build(BuildContext context) {
     return PopScope(
       canPop: !_isEdited,
-      onPopInvokedWithResult: (didPop, result) async {
+      onPopInvoked: (didPop) async {
         if (didPop) return;
         final shouldPop = await showDialog<bool>(
           context: context,


### PR DESCRIPTION
## Summary
- fix incorrect `PopScope` callback parameter name

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684634be8fe08323abd1c1929e3cdb2b