### PR TITLE
Implement platform-specific auto lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ A fully local encrypted note-taking app that prioritizes your privacy and securi
 - 💻 100% local storage - your data never leaves your device
 - 📱 Cross-platform support (iOS & Android)
 - 🔒 End-to-end encryption using PBKDF2 key derivation and AES-256 with IV
+- 🔐 Automatic locking when the app goes to the background on Android and iOS.
+  On Windows and macOS the app locks after 1 minute in the background or when
+  the desktop is locked.
 
 
 Copyright (c) 2025 Jayden Kan


### PR DESCRIPTION
## Summary
- lock the app automatically when it goes to the background on Android/iOS
- add a one minute timer before locking on Windows/macOS
- document the new behaviour in the README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684636e83f9883239d4a804e8a19ff48