### PR TITLE
fix: adjust base path for GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,20 @@
 <head>
     <meta charset="utf-8">
     <title>Redirecting to Local Keep</title>
-    <meta http-equiv="refresh" content="0; url=./web/">
-    <link rel="canonical" href="./web/">
+    <script>
+      // Redirect to the Flutter web build regardless of the repository name
+      var path = window.location.pathname.replace(/[^/]*$/, '') + 'web/';
+      window.location.replace(path);
+    </script>
+    <link id="canonical-link" rel="canonical" href="./web/">
 </head>
 <body>
-    <p>If you are not redirected automatically, <a href="./web/">click here to access Local Keep</a>.</p>
+    <p>If you are not redirected automatically, <a id="redirect-link" href="./web/">click here to access Local Keep</a>.</p>
+    <script>
+      // Update the fallback link to the correct path
+      var path = window.location.pathname.replace(/[^/]*$/, '') + 'web/';
+      document.getElementById('redirect-link').href = path;
+      document.getElementById('canonical-link').href = path;
+    </script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -15,6 +15,14 @@
     the `--base-href` argument provided to `flutter build`.
   -->
   <base href="$FLUTTER_BASE_HREF">
+  <script>
+    // When hosted on GitHub Pages the app is served from a subfolder.
+    // Update the base href dynamically so Flutter can load its assets
+    // regardless of the repository name.
+    var baseTag = document.querySelector('base');
+    var path = window.location.pathname.split('/').slice(0, -1).join('/') + '/';
+    baseTag.setAttribute('href', path);
+  </script>
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">


### PR DESCRIPTION
## Summary
- dynamically redirect to the built Flutter web app regardless of repository path
- adjust base href at runtime so assets load when hosted on GitHub Pages

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed / 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688e3a7860908323803f7320940158ff